### PR TITLE
Correcting for Net::HTTPResponse behavior

### DIFF
--- a/developer signatures/AvocadoSignTest.rb
+++ b/developer signatures/AvocadoSignTest.rb
@@ -55,9 +55,9 @@ class AvocadoAPI
     connection = Net::HTTP::new($AVOCADO_API_HOST, $AVOCADO_API_PORT)
     connection.verify_mode = OpenSSL::SSL::VERIFY_NONE
     connection.use_ssl = true
-    resp, data = connection.get($AVOCADO_API_URL_COUPLE, get_signed_headers)
+    resp = connection.get($AVOCADO_API_URL_COUPLE, get_signed_headers)
     if resp.code == "200"
-      @couple = data
+      @couple = resp.body
     end
   end
 


### PR DESCRIPTION
Net::HTTP#get returns an Net::HTTPResponse object, rather than the object-and-data response the current file is expecting. As a result, the process always fails because data will always be nil, regardless of the GET request’s success.
